### PR TITLE
Fix problem where the deployment returns w/o an IP address

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Vagrant VRealize Provider
 
-This is a [Vagrant](http://www.vagrantup.com) 1.2+ plugin that adds a VDC
+This is a [Vagrant](http://www.vagrantup.com) 1.2+ plugin that adds a VMware vRealize Automation 
 provider to Vagrant, allowing Vagrant to control and provision machines in
 VRealize.
 

--- a/lib/vagrant-vrealize/action/terminate_instance.rb
+++ b/lib/vagrant-vrealize/action/terminate_instance.rb
@@ -15,6 +15,48 @@ module VagrantPlugins
           vra = env[:vra]
           vra.destroy(env[:machine].id) if env[:machine].id
 
+          # Destroy action_provision
+          action_provision_file = env[:machine].data_dir.join('action_provision')
+          if action_provision_file.file?
+            action_provision_file.delete
+          end
+
+          # Destroy creator_uid
+          creator_uid_file = env[:machine].data_dir.join('creator_uid')
+          if creator_uid_file.file?
+            creator_uid_file.delete
+          end
+
+          # Destroy elastic_ip
+          elastic_ip_file = env[:machine].data_dir.join('elastic_ip')
+          if elastic_ip_file.file?
+            elastic_ip_file.delete
+          end
+
+          # Destroy id
+          id_file = env[:machine].data_dir.join('id')
+          if id_file.file?
+            id_file.delete
+          end
+
+          # Destroy index_uuid
+          index_uuid_file = env[:machine].data_dir.join('index_uuid')
+          if index_uuid_file.file?
+            index_uuid_file.delete
+          end
+
+          # Destroy private_key
+          private_key_file = env[:machine].data_dir.join('private_key')
+          if private_key_file.file?
+            private_key_file.delete
+          end
+
+          # Destroy synced_folders
+          synced_folders_file = env[:machine].data_dir.join('synced_folders')
+          if synced_folders_file.file?
+            synced_folders_file.delete
+          end
+
           @app.call(env)
         end
       end

--- a/lib/vagrant-vrealize/vra_client.rb
+++ b/lib/vagrant-vrealize/vra_client.rb
@@ -101,7 +101,8 @@ module VagrantPlugins
 
       def machine
         if done?
-          @request.resources.first
+          # expecting only one VM, but should check and error out if there are more
+          @request.resources.select { |a| a.vm? }.first
         end
       end
 


### PR DESCRIPTION
This fixes an error that surfaces in run_instance.rb:

`/Users/rynelson/.vagrant.d/gems/2.2.5/gems/vagrant-vrealize-0.0.4/lib/vagrant-vrealize/action/run_instance.rb:73:in `block in save_ip_address': undefined method `first' for nil:NilClass (NoMethodError)`

When creating a new VM, a new deployment also gets created in vRealize.  And when the plugin retrieves all resources associated with a request, vRA returns both the deployment and the VM (non-deterministic as to which is first).

When the VM is first, the plugin locates the IP correctly and everything is fine.  When the deployment happens to be first, there is no IP present, and the plugin fails.  This fix ensures that a VM is always returned.